### PR TITLE
include pytest to environment.yml

### DIFF
--- a/environments/environment.yml
+++ b/environments/environment.yml
@@ -31,3 +31,4 @@ dependencies:
   - ipykernel
   - google-cloud-storage
   - pyprojroot
+  - pytest


### PR DESCRIPTION
You might not want to include pytest for the end user, but even so it can be a nice way for people to check that everything is working? Also for CI you will need to have pytest in your environment folders for the remote machine to run your tests. Maybe premature ?