### PR TITLE
Refactor datamodule

### DIFF
--- a/ml4floods/data/worldfloods/dataset.py
+++ b/ml4floods/data/worldfloods/dataset.py
@@ -114,8 +114,6 @@ class WorldFloodsDatasetTiled(Dataset):
             namedtuples each consisting of a filename and a rasterio.window
         image_prefix (str): the input folder sub_directory
         gt_prefix (str): the target folder sub directory
-        window_size (Tuple[int,int]): the window sizes (height, width) to be
-            used for the tiling
         transforms (Callable): the transformations used within the
             training data module
 
@@ -124,8 +122,6 @@ class WorldFloodsDatasetTiled(Dataset):
             namedtuples each consisting of a filename and a rasterio.window
         image_prefix (str): the input folder sub_directory
         gt_prefix (str): the target folder sub directory
-        window_size (namedtuple): a tuple with the height and width
-            arguments
         transforms (Callable): the transformations used within the
             training data module
         bands: List[int]
@@ -251,6 +247,7 @@ def rasterio_read(
 
 def load_input(tiff_input:str, channels:List[int], window:Optional[rasterio.windows.Window]=None) -> Tuple[torch.Tensor, rasterio.transform.Affine]:
     """
+    Reads from a tiff the specified channel and window.
 
     Args:
         tiff_input:
@@ -258,7 +255,7 @@ def load_input(tiff_input:str, channels:List[int], window:Optional[rasterio.wind
         channels: 0-based channels to read
 
     Returns:
-        3-D tensor (len(channels), H, W)
+        3-D tensor (len(channels), H, W), Affine transform to geo-reference the array read.
 
     """
     with rasterio.open(tiff_input, "r") as rst:

--- a/ml4floods/data/worldfloods/dataset.py
+++ b/ml4floods/data/worldfloods/dataset.py
@@ -221,7 +221,7 @@ class WorldFloodsDatasetTiled(Dataset):
         # get rid of nan, convert to float
         image = np.nan_to_num(image_tif).astype(np.float32)
 
-        mask = np.nan_to_num(mask_tif)
+        mask = np.nan_to_num(mask_tif).astype(int)
 
         # Apply transformation
         if self.transforms is not None:

--- a/ml4floods/data/worldfloods/lightning.py
+++ b/ml4floods/data/worldfloods/lightning.py
@@ -58,7 +58,7 @@ class WorldFloodsDataModule(pl.LightningDataModule):
             the training, validation and test splits 
       
     Example:
-        >>> from ml4floods.data.worldfloods.lightning import WorldFloodsGCPDataModule
+        >>> from ml4floods.data.worldfloods.lightning import WorldFloodsDataModule
         >>> wf_dm = WorldFloodsDataModule()
         >>> wf_dm.prepare_data()
         >>> wf_dm.setup()
@@ -67,27 +67,27 @@ class WorldFloodsDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
-        data_dir: str = "./",
         input_folder: str = "S2",
         target_folder: str = "gt",
         train_transformations: Optional[Callable] = None,
         test_transformations: Optional[Callable] = None,
-        window_size: Tuple[int, int] = [64, 64],
+        window_size: Tuple[int, int] = (64, 64),
         batch_size: int = 32,
         bands: List[int] = [1, 2, 3],
         num_workers:int = 4,
         num_workers_val:int = 0,
         num_workers_test: int = 0,
         filter_windows:Callable = None,
-        filenames_train_test: Dict = None
+        lock_read: bool = False,
+        filenames_train_test: Optional[Dict] = None
     ):
         super().__init__()
-        self.data_dir = data_dir
         self.train_transform = train_transformations
         self.test_transform = test_transformations
         self.num_workers = num_workers
         self.num_workers_test = num_workers_test
         self.num_workers_val = num_workers_val
+        self.lock_read = lock_read
 
         # self.dims is returned when you call dm.size()
         # Setting default dims here because we know them.
@@ -101,6 +101,18 @@ class WorldFloodsDataModule(pl.LightningDataModule):
         self.window_size = WindowSize(height=window_size[0], width=window_size[1])
         self.filenames_train_test = filenames_train_test
 
+        files = {}
+        splits = ["train", "test", "val"]
+
+        # loop through the naming splits
+        for isplit in splits:
+                files[isplit] = self.filenames_train_test[isplit]['S2']
+
+        # save filenames
+        self.train_files = files["train"]
+        self.val_files = files["val"]
+        self.test_files = files["test"]
+
     def prepare_data(self):
         """Does Nothing for now. Here for compatibility."""
         # TODO: here we can check for correspondence between the files
@@ -110,49 +122,18 @@ class WorldFloodsDataModule(pl.LightningDataModule):
         """This creates the PyTorch dataset given the preconfigured
         file paths.
         """
-        files = {}
-        splits = ["train", "test", "val"]   
-        
-        # loop through the naming splits
-        for isplit in splits:
-            
-            if not self.filenames_train_test[isplit]['S2']:
-                
-                #get the subdirectory
-                sub_dir = Path(self.data_dir).joinpath(isplit).joinpath(self.image_prefix)
-                # append filenames to split dictionary
-                files[isplit] = get_files_in_directory(sub_dir, "tif")        
-                
-            else:
-                files[isplit] = self.filenames_train_test[isplit]['S2']
-            
-            # save filenames
-            
-        self.train_files = files["train"]
-        self.val_files = files["val"]
-        self.test_files = files["test"]            
-    
 
+        self.train_dataset = WorldFloodsDatasetTiled(
+            list_of_windows=get_list_of_window_slices(self.train_files, window_size=self.window_size),
+            image_prefix=self.image_prefix,
+            gt_prefix=self.gt_prefix,
+            bands=self.bands,
+            transforms=self.train_transform,
+            lock_read=self.lock_read
+        )
         if self.filter_windows is not None:
-            self.train_dataset = WorldFloodsDatasetTiled(
-                list_of_windows=get_list_of_window_slices(self.train_files, window_size=self.window_size),
-                image_prefix=self.image_prefix,
-                gt_prefix=self.gt_prefix,
-                bands=self.bands,
-                transforms=self.train_transform,
-            )
             self.train_dataset.list_of_windows = self.filter_windows(self.train_dataset)
 
-        else:
-            # create datasets
-            self.train_dataset = WorldFloodsDatasetTiled(
-                list_of_windows=get_list_of_window_slices(self.train_files, window_size=self.window_size),
-                image_prefix=self.image_prefix,
-                gt_prefix=self.gt_prefix,
-                bands=self.bands,
-                transforms=self.train_transform,
-            )
-
         self.val_dataset = WorldFloodsDatasetTiled(
             list_of_windows=get_list_of_window_slices(
                 self.val_files, window_size=self.window_size
@@ -161,162 +142,16 @@ class WorldFloodsDataModule(pl.LightningDataModule):
             gt_prefix=self.gt_prefix,
             bands=self.bands,
             transforms=self.test_transform,
+            lock_read=self.lock_read
         )
+
         self.test_dataset = WorldFloodsDataset(
             image_files=self.test_files,
             image_prefix=self.image_prefix,
             gt_prefix=self.gt_prefix,
             bands=self.bands,
             transforms=self.test_transform,
-        )
-
-    def train_dataloader(self):
-        """Initializes and returns the training dataloader"""
-        return DataLoader(self.train_dataset, batch_size=self.batch_size,
-                          num_workers=self.num_workers, shuffle=True)
-
-    def val_dataloader(self, num_workers=None):
-        """Initializes and returns the validation dataloader"""
-        num_workers = num_workers or self.num_workers_val
-        return DataLoader(self.val_dataset, batch_size=self.batch_size,
-                          num_workers=num_workers, shuffle=False)
-
-    def test_dataloader(self, num_workers=None):
-        """Initializes and returns the test dataloader"""
-        num_workers = num_workers or self.num_workers_test
-        return DataLoader(self.test_dataset, batch_size=1,
-                          num_workers=num_workers, shuffle=False)
-
-
-class WorldFloodsGCPDataModule(pl.LightningDataModule):
-    """A prepackaged WorldFloods Pytorch-Lightning data module
-    This initializes a module given a GCP bucket. We define a bucket and a
-    top level directory followed by subdirectories for the training and
-    testing data ("image_folder" and "target_folder").
-    Then we can search through the directory and load the images found. It
-    creates the train, val and test datasets which then can be used to initialize
-    the dataloaders. This is pytorch lightning compatible which can be used with
-    the training fit framework.
-
-    Args:
-        bucket_id (str): the GCP bucket name
-        filenames_train_test: (str): Dict with the train, test and validation images
-        input_folder (str): the input folder sub_directory
-        target_folder (str): the target folder sub directory
-        train_transformations (Callable): the transformations used within the
-            training data module
-        test_transformations (Callable): the transformations used within the
-            testing data module
-        window_size (Tuple[int,int]): the window size used to tile the images
-            for training
-        batch_size (int): the batchsize used for the dataloader
-        bands (List(int)): the bands to be selected from the images
-
-    Attributes:
-        data_dir: (str): the top level directory where the input
-            and target folder directories are found
-        train_transform (Callable): the transformations used within the
-            training data module
-        test_transform (Callable): the transformations used within the
-            testing data module
-        bands (List(int)): the bands to be selected from the images
-        input_prefix (str): the input folder sub_directory
-        target_prefix (str): the target folder sub directory
-        window_size (Tuple[int,int]): the window size used to tile the images
-                    for training
-
-    Example:
-        >>> from ml4floods.data.worldfloods.lightning import WorldFloodsGCPDataModule
-        >>> wf_dm = WorldFloodsGCPDataModule()
-        >>> wf_dm.prepare_data()
-        >>> wf_dm.setup()
-        >>> train_dl = wf_dm.train_dataloader()
-    """
-
-    def __init__(
-        self,
-        bucket_id: str = "ml4floods",
-        filenames_train_test: Dict[str, Dict[str, List[str]]] = None,
-        input_folder: str = "S2",
-        target_folder: str = "gt",
-        train_transformations: Optional[Callable] = None,
-        test_transformations: Optional[Callable] = None,
-        window_size: Tuple[int, int] = [64, 64],
-        batch_size: int = 32,
-        bands: List[int] = [1, 2, 3],
-        num_workers: int = 4,
-        num_workers_val: int = 0,
-        num_workers_test: int = 0,
-    ):
-        super().__init__()
-        self.train_transform = train_transformations
-        self.test_transform = test_transformations
-        self.num_workers = num_workers
-        self.num_workers_test = num_workers_test
-        self.num_workers_val = num_workers_val
-
-        # WORLDFLOODS Directories
-        self.bucket_name = bucket_id
-        self.train_files = filenames_train_test["train"][input_folder]
-        self.val_files = filenames_train_test["val"][input_folder]
-        self.test_files = filenames_train_test["test"][input_folder]
-
-        # TODO: make this cleaner...this feels hacky.
-        self.train_files = [f"gs://{self.bucket_name}/{x}" for x in self.train_files]
-        self.val_files = [f"gs://{self.bucket_name}/{x}" for x in self.val_files]
-        self.test_files = [f"gs://{self.bucket_name}/{x}" for x in self.test_files]
-
-        # self.dims is returned when you call dm.size()
-        # Setting default dims here because we know them.
-        # Could optionally be assigned dynamically in dm.setup()
-        self.bands = bands
-        self.batch_size = batch_size
-        # Prefixes
-        self.image_prefix = input_folder
-        self.gt_prefix = target_folder
-        self.window_size = WindowSize(height=window_size[0], width=window_size[1])
-
-    def prepare_data(self):
-        """Does Nothing for now. Here for compatibility."""
-        # TODO: here we can check for correspondence between the files
-        pass
-
-    def setup(self):
-        """This creates the PyTorch dataset given the preconfigured
-        file paths in the bucket. This also does the tiling operations.
-        """
-        # get filenames from the bucket
-
-        # add gcp dir to each of the strings
-
-        # create datasets
-        self.train_dataset = WorldFloodsDatasetTiled(
-            list_of_windows=get_list_of_window_slices(
-                self.train_files, window_size=self.window_size
-            ),
-            image_prefix=self.image_prefix,
-            gt_prefix=self.gt_prefix,
-            transforms=self.train_transform,
-            bands=self.bands,
-            lock_read=True,
-        )
-        self.val_dataset = WorldFloodsDatasetTiled(
-            list_of_windows=get_list_of_window_slices(
-                self.val_files, window_size=self.window_size
-            ),
-            image_prefix=self.image_prefix,
-            gt_prefix=self.gt_prefix,
-            transforms=self.test_transform,
-            bands=self.bands,
-            lock_read=True,
-        )
-        self.test_dataset = WorldFloodsDataset(
-            image_files=self.test_files,
-            image_prefix=self.image_prefix,
-            gt_prefix=self.gt_prefix,
-            transforms=self.test_transform,
-            bands=self.bands,
-            lock_read=True,
+            lock_read=self.lock_read
         )
 
     def train_dataloader(self):

--- a/ml4floods/data/worldfloods/lightning.py
+++ b/ml4floods/data/worldfloods/lightning.py
@@ -12,7 +12,6 @@ from typing import Tuple, Optional, List, Callable, Dict
 from torch.utils.data import DataLoader
 from ml4floods.data.worldfloods.dataset import WorldFloodsDatasetTiled, WorldFloodsDataset
 import pytorch_lightning as pl
-from pathlib import Path
 from ml4floods.preprocess.tiling import WindowSize
 from ml4floods.preprocess.utils import get_list_of_window_slices
 

--- a/ml4floods/data/worldfloods/lightning.py
+++ b/ml4floods/data/worldfloods/lightning.py
@@ -1,13 +1,3 @@
-from pathlib import Path
-from typing import Callable, List, Optional, Tuple
-
-import albumentations
-import pytorch_lightning as pl
-from torch.utils.data import DataLoader, random_split
-
-from ml4floods.data.utils import get_files_in_bucket_directory, get_files_in_directory
-from ml4floods.data.worldfloods.dataset import WorldFloodsDatasetTiled
-from ml4floods.data.utils import get_files_in_directory
 from typing import Tuple, Optional, List, Callable, Dict
 from torch.utils.data import DataLoader
 from ml4floods.data.worldfloods.dataset import WorldFloodsDatasetTiled, WorldFloodsDataset
@@ -26,8 +16,6 @@ class WorldFloodsDataModule(pl.LightningDataModule):
     the training fit framework.
 
     Args:
-        data_dir: (str): the top level directory where the input
-            and target folder directories are found
         input_folder (str): the input folder sub_directory
         target_folder (str): the target folder sub directory
         train_transformations (Callable): the transformations used within the
@@ -40,8 +28,6 @@ class WorldFloodsDataModule(pl.LightningDataModule):
         bands (List(int)): the bands to be selected from the images
 
     Attributes:
-        data_dir: (str): the top level directory where the input
-            and target folder directories are found
         train_transform (Callable): the transformations used within the
             training data module
         test_transform (Callable): the transformations used within the
@@ -66,6 +52,7 @@ class WorldFloodsDataModule(pl.LightningDataModule):
 
     def __init__(
         self,
+        filenames_train_test: Dict,
         input_folder: str = "S2",
         target_folder: str = "gt",
         train_transformations: Optional[Callable] = None,
@@ -78,7 +65,6 @@ class WorldFloodsDataModule(pl.LightningDataModule):
         num_workers_test: int = 0,
         filter_windows:Callable = None,
         lock_read: bool = False,
-        filenames_train_test: Optional[Dict] = None
     ):
         super().__init__()
         self.train_transform = train_transformations
@@ -105,7 +91,8 @@ class WorldFloodsDataModule(pl.LightningDataModule):
 
         # loop through the naming splits
         for isplit in splits:
-                files[isplit] = self.filenames_train_test[isplit]['S2']
+                # TODO we might could use the train_test_split dict for avoiding to use the image_prefix and gt_prefix
+                files[isplit] = self.filenames_train_test[isplit][self.image_prefix]
 
         # save filenames
         self.train_files = files["train"]

--- a/ml4floods/models/dataset_setup.py
+++ b/ml4floods/models/dataset_setup.py
@@ -103,7 +103,8 @@ def process_filename_train_test(train_test_split_file:Optional[str]="gs://ml4cc_
         for idx, filename in enumerate(filenames_train_test[isplit][input_folder]):
             fs = get_filesystem(filename)
             assert fs.exists(filename), f"File input: {filename} does not exists"
-            filename_target = filename.replace(input_folder, target_folder, 1)
+
+            filename_target = filenames_train_test[isplit][target_folder][idx]
             assert fs.exists(filename_target), f"File target: {filename_target} does not exists"
 
             # Download if needed and replace filenames_train_test with the downloaded version
@@ -158,6 +159,7 @@ def get_dataset(data_config) -> pl.LightningDataModule:
 
     # CREATE DATAMODULE
     datamodule = WorldFloodsDataModule(
+        filenames_train_test=filenames_train_test,
         input_folder=data_config.input_folder,
         target_folder=data_config.target_folder,
         train_transformations=train_transform,
@@ -166,8 +168,7 @@ def get_dataset(data_config) -> pl.LightningDataModule:
         num_workers=data_config.num_workers,
         window_size=data_config.window_size,
         batch_size=data_config.batch_size,
-        filter_windows= filter_windows_config,
-        filenames_train_test=filenames_train_test
+        filter_windows= filter_windows_config
     )
     datamodule.setup()
 

--- a/ml4floods/models/dataset_setup.py
+++ b/ml4floods/models/dataset_setup.py
@@ -1,17 +1,17 @@
 from ml4floods.preprocess.worldfloods import normalize as wf_normalization
 import ml4floods.preprocess.transformations as transformations
-from ml4floods.preprocess.tiling import WindowSize, WindowSlices, save_tiles, load_windows, save_windows
-from ml4floods.data import utils
+from ml4floods.preprocess.tiling import WindowSlices, load_windows, save_windows
+from glob import glob
 from ml4floods.data.worldfloods.configs import CHANNELS_CONFIGURATIONS
 from ml4floods.data.worldfloods.dataset import WorldFloodsDatasetTiled
+from ml4floods.data.worldfloods.lightning import WorldFloodsDataModule
 from ml4floods.models.utils.configuration import AttrDict
 import pytorch_lightning as pl
 import os
 import json
 from typing import Dict, List, Callable, Tuple, Optional
 from ml4floods.preprocess.worldfloods import prepare_patches
-from ml4floods.models.config_setup import load_json
-import fsspec
+from ml4floods.models.config_setup import load_json, get_filesystem
 import warnings
 
 
@@ -26,137 +26,158 @@ def filenames_train_test_split(bucket_name:Optional[str], train_test_split_file:
     Returns:
 
     """
-    if bucket_name != "" and bucket_name is not None:
-        return load_json(f"gs://{bucket_name}/{train_test_split_file}")
+    if bucket_name or train_test_split_file.startswith("gs://"):
+        if not train_test_split_file.startswith("gs://"):
+            train_test_split_file = f"gs://{bucket_name}/{train_test_split_file}"
+        filenames_train_test = load_json(train_test_split_file)
+
+        # Preprend the bucket name to the files
+        for splitname, split in filenames_train_test.items():
+            for foldername, listoftiffs in split.items():
+                for idx,tiffname in enumerate(listoftiffs):
+                    if not tiffname.startswith("gs://"):
+                        tiffname = f"gs://{bucket_name}/{tiffname}"
+                        # assert fs.exists(tiffname), f"File {tiffname} does not exists"
+                        listoftiffs[idx] = tiffname
     else:
         with open(train_test_split_file, "r") as fh:
-            return json.load(fh)
+            filenames_train_test = json.load(fh)
+
+    return filenames_train_test
+
+
+def process_filename_train_test(train_test_split_file:Optional[str]="gs://ml4cc_data_lake/2_PROD/2_Mart/worldfloods_v1_0/train_test_split.json",
+                                input_folder:str="S2",
+                                target_folder:str="gt",
+                                bucket_id:Optional[str]=None, path_to_splits:Optional[str]=None,
+                                download:Optional[Dict[str,bool]]=None) -> Dict[str,Dict[str, List[str]]]:
+    """
+    The train_test_split_file contains which files go to the train/val/test splits. This function validate that
+    the content is as expected and that all files referred there exists. Additionally it downloads the data to loca
+    if specified.
+
+    Args:
+        train_test_split_file:
+        input_folder:
+        target_folder:
+        bucket_id:
+        path_to_splits:
+        download: e.g. `{"train": True, "val": False, "test": True}` to download train and val data.
+
+    Returns:
+
+    """
+
+    if download is None:
+        download = {"train": False, "val": False, "test": False}
+
+    if train_test_split_file is not None:
+        filenames_train_test = filenames_train_test_split(bucket_id, train_test_split_file)
+    else:
+        assert (path_to_splits is not None) and os.path.exists(path_to_splits), \
+            f"train_test_split_file not provided and path_to_splits folder {path_to_splits} does not exist"
+
+        print(f"train_test_split_file not provided. We will use the content in the folder {path_to_splits}")
+        filenames_train_test = {'train': {target_folder:[], input_folder:[]},
+                                'test': {target_folder:[],input_folder:[]},
+                                'val': {target_folder:[],input_folder:[]}}
+
+    # loop through the naming splits
+    for isplit in ["train", "test", "val"]:
+        for foldername in [input_folder, target_folder]:
+
+            # glob files in path_to_splits dir if there're not files in the given split
+            if len(filenames_train_test[isplit][foldername]) == 0:
+                # get the subdirectory
+                assert (path_to_splits is not None) and os.path.exists(path_to_splits), \
+                    f"path_to_splits {path_to_splits} doesn't exists or not provided and there're no files in split {isplit} folder {foldername}"
+
+                path_2_glob = os.path.join(path_to_splits, isplit, foldername, "*.tif")
+                filenames_train_test[isplit][foldername] = glob(path_2_glob)
+                assert len(filenames_train_test[isplit][foldername]) > 0, f"No files found in {path_2_glob}"
+
+        assert len(filenames_train_test[isplit][input_folder]) == len(filenames_train_test[isplit][target_folder]), \
+            f"Different number of files in {input_folder} and {target_folder} for split {isplit}: {len(filenames_train_test[isplit][input_folder])} {len(filenames_train_test[isplit][target_folder])}"
+
+        # check correspondence input output files (assert files exists)
+        for idx, filename in enumerate(filenames_train_test[isplit][input_folder]):
+            fs = get_filesystem(filename)
+            assert fs.exists(filename), f"File input: {filename} does not exists"
+            filename_target = filename.replace(input_folder, target_folder, 1)
+            assert fs.exists(filename_target), f"File target: {filename_target} does not exists"
+
+            # Download if needed and replace filenames_train_test with the downloaded version
+            if filename.startswith("gs://") and download[isplit]:
+                assert (path_to_splits is not None) and os.path.exists(path_to_splits), \
+                    f"path_to_splits {path_to_splits} doesn't exists or not provided ad requested to download the data"
+
+                for input_target_folder in [input_folder, target_folder]:
+                    folder_local = os.path.join(path_to_splits, isplit, input_target_folder)
+                    os.makedirs(folder_local, exist_ok=True)
+                    basename = os.path.basename(filename)
+                    file_dest = os.path.join(folder_local, basename)
+                    if not os.path.isfile(file_dest):
+                        fs.get_file(filename, file_dest)
+                        print(f"Downloaded ({idx}/{len(filenames_train_test[isplit][input_folder])}) {filename}")
+                    filenames_train_test[isplit][input_folder][idx] = file_dest
+
+    return filenames_train_test
 
 
 def get_dataset(data_config) -> pl.LightningDataModule:
     """
     Function to set up dataloaders for model training
-    option 1: Local
-    option 2: Local Tiles (buggy)
-    option 3: GCP Bucket (buggy)
     """
     
     # 1. Setup transformations for dataset
     
     train_transform, test_transform = get_transformations(data_config)
 
-    bands = CHANNELS_CONFIGURATIONS[data_config.channel_configuration]
-    window_size = WindowSize(height=data_config.window_size[0], width=data_config.window_size[1])
+    # ======================================================
+    # Obtain train/val/test files
+    # ======================================================
+    download = data_config.get("download")
+    if download is None:
+        download = {"train": data_config.get("loader_type","local")=="local",
+                    "val": data_config.get("loader_type","local")=="local",
+                    "test": data_config.get("loader_type","local")=="local"}
 
-    # ======================================================
-    # LOCAL PREPARATION
-    # ======================================================
-    local_destination_dir = data_config.path_to_splits
-    if data_config.train_test_split_file is not None:
-        filenames_train_test = filenames_train_test_split(data_config.bucket_id, data_config.train_test_split_file)
+    filenames_train_test = process_filename_train_test(data_config.get("train_test_split_file"),
+                                                       data_config.input_folder, data_config.target_folder,
+                                                       data_config.get("bucket_id"),
+                                                       path_to_splits=data_config.get("path_to_splits"),
+                                                       download=download)
+
+    filter_windows_attr = data_config.get("filter_windows", None)
+    if filter_windows_attr is not None and filter_windows_attr.get("apply", False):
+        filter_windows_config = filter_windows_fun(data_config.filter_windows.version,
+                                                   threshold_clouds=data_config.filter_windows.threshold_clouds,
+                                                   local_destination_dir=data_config.path_to_splits)
     else:
-        filenames_train_test = {'train': {'gt':[],'S2':[]},'test': {'gt':[],'S2':[]},'val': {'gt':[],'S2':[]}}
-# ======================================================
-    # LOCAL DATASET SETUP
-    # ======================================================
-    if data_config.loader_type == 'local':
-        from ml4floods.data.worldfloods.lightning import WorldFloodsDataModule
-        print('Using local dataset for this run')
-        
-        # Read Files from bucket and copy them in local_destination_dir
-        if data_config.bucket_id is not None:
-            download_tiffs_from_bucket(data_config.bucket_id,
-                                       [data_config.input_folder, data_config.target_folder],
-                                       filenames_train_test, local_destination_dir,
-                                       download=data_config.get("download", None))
+        filter_windows_config = None
 
-        filter_windows_attr = data_config.get("filter_windows", None)
-        if filter_windows_attr is not None and filter_windows_attr.get("apply", False):
-            filter_windows_config = filter_windows_fun(data_config.filter_windows.version,
-                                                       threshold_clouds=data_config.filter_windows.threshold_clouds,
-                                                       local_destination_dir=local_destination_dir)
-        else:
-            filter_windows_config = None
-        # CREATE DATAMODULE
-        dataset = WorldFloodsDataModule(
-            input_folder=data_config.input_folder,
-            target_folder=data_config.target_folder,
-            train_transformations=train_transform,
-            test_transformations=test_transform,
-            data_dir=local_destination_dir,
-            bands=bands,
-            num_workers=data_config.num_workers,
-            window_size=data_config.window_size,
-            batch_size=data_config.batch_size,
-            filter_windows= filter_windows_config,
-            filenames_train_test=filenames_train_test
-        )
-        dataset.setup()
-            
-    # ======================================================
-    # LOCAL TILED DATASET SETUP
-    # ======================================================
-    # elif data_config.loader_type == 'local_tiles':
-    #     print('Using local pre-tiled dataset for this run')
-    #
-    #     # Read Files from bucket
-    #     for split in filenames_train_test.keys():
-    #         for k in filenames_train_test[split].keys():
-    #             create_folder(f"{local_destination_dir}_tiles/{split}/{k}")
-    #             cur_bands = bands if data_config.input_folder == k else [1,]
-    #             for fp in filenames_train_test[split][k]:
-    #                 raw_fp = fp.split(f"{split}/{k}/")[1].split('.tif')[0]
-    #                 if not os.path.isfile(f"{local_destination_dir}_tiles/{split}/{k}/{raw_fp}_tile_0.tif"):
-    #                     save_tiles(f"gs://{data_config.bucket_id}/{fp}", f"{local_destination_dir}_tiles/{split}/{k}/", cur_bands, window_size)
-    #                     print(f'Loaded {fp}')
-    #                 else:
-    #                     print(f'Tiles for {fp} already exist')
-    #
-    #     # CREATE DATASET
-    #     dataset = WorldFloodsDataModule(
-    #         input_folder=data_config.input_folder,
-    #         target_folder=data_config.target_folder,
-    #         train_transformations=train_transform,
-    #         test_transformations=test_transform,
-    #         data_dir=destination_dir,
-    #         bands=bands,
-    #         window_size=data_config.window_size,
-    #         batch_size=data_config.batch_size)
-    #     dataset.setup()
-        
-    
-    # ======================================================
-    # GCP BUCKET DATASET SETUP
-    # ======================================================    
-    elif data_config.loader_type == 'bucket':
-        print('Using remote bucket storate dataset for this run')
-        from ml4floods.data.worldfloods.lightning import WorldFloodsGCPDataModule
-        
-        dataset = WorldFloodsGCPDataModule(
-            bucket_id=data_config.bucket_id,
-            filenames_train_test=filenames_train_test,
-            input_folder=data_config.input_folder,
-            target_folder=data_config.target_folder,
-            window_size=window_size,
-            bands=bands,
-            train_transformations=train_transform,
-            test_transformations=test_transform,
-            batch_size=data_config.batch_size,
-            num_workers=data_config.num_workers,
-        )
-        dataset.setup()
-        
-    else:
-        raise Exception(f"No dataset implemented for loader_type: {data_config.loader_type}")
-        
-    
-    print("train", dataset.train_dataset.__len__(), " tiles")
-    print("val", dataset.val_dataset.__len__(), " tiles")
-    print("test", dataset.test_dataset.__len__(), " tiles")
-    
-    return dataset
+    # CREATE DATAMODULE
+    datamodule = WorldFloodsDataModule(
+        input_folder=data_config.input_folder,
+        target_folder=data_config.target_folder,
+        train_transformations=train_transform,
+        test_transformations=test_transform,
+        bands=CHANNELS_CONFIGURATIONS[data_config.channel_configuration],
+        num_workers=data_config.num_workers,
+        window_size=data_config.window_size,
+        batch_size=data_config.batch_size,
+        filter_windows= filter_windows_config,
+        filenames_train_test=filenames_train_test
+    )
+    datamodule.setup()
 
-def filter_windows_fun(data_version:str, local_destination_dir:str, threshold_clouds=.5) -> Callable:
+    print("train", datamodule.train_dataset.__len__(), " tiles")
+    print("val", datamodule.val_dataset.__len__(), " tiles")
+    print("test", datamodule.test_dataset.__len__(), " tiles")
+    
+    return datamodule
+
+def filter_windows_fun(data_version:str, local_destination_dir:Optional[str]=None, threshold_clouds=.5) -> Callable:
     """
     Returns a function to filter the windows in the  WorldFloodsDatasetTiled dataset. This is used for pre-filtering
     the training images to discard patches with high cloud content.
@@ -171,9 +192,13 @@ def filter_windows_fun(data_version:str, local_destination_dir:str, threshold_cl
         function to filter windows
 
     """
-    windows_file = os.path.join(local_destination_dir, f"windows_{data_version}.json")
+    if local_destination_dir is not None:
+        windows_file = os.path.join(local_destination_dir, f"windows_{data_version}.json")
+    else:
+        windows_file = None
+
     def filter_windows(tiledDataset: WorldFloodsDatasetTiled) -> List[WindowSlices]:
-        if os.path.exists(windows_file):
+        if windows_file and os.path.exists(windows_file):
             selected_windows = load_windows(windows_file)
         else:
             if data_version == "v1":
@@ -183,53 +208,14 @@ def filter_windows_fun(data_version:str, local_destination_dir:str, threshold_cl
                 selected_windows = prepare_patches.filter_windows_v2(tiledDataset,
                                                                      threshold_clouds=threshold_clouds)
             else:
-                raise NotImplementedError(f"Unknown data version {data_version} expected v1 or v2")
+                raise NotImplementedError(f"Unknown ground truth version {data_version} expected v1 or v2")
 
-            save_windows(selected_windows, windows_file)
+            if windows_file:
+                save_windows(selected_windows, windows_file)
 
         return selected_windows
 
     return filter_windows
-
-def download_tiffs_from_bucket(bucket_id, input_target_folders, filenames:Dict[str,Dict[str,List[str]]],
-                               local_destination_dir, verbose=False, download=None):
-    """
-    Given files in the filenames dict. It downloads all to the local_destination_dir.
-    Specifically if input_target_folders is ["S2", "gt"] the data will be downloaded to:
-
-    local_destination_dir/(train|val|test)/(S2|gt)/***.tif
-    Args:
-        bucket_id:
-        input_target_folders: folders to download ["S2", "gt"] for training
-        filenames: Dict object with files to use for train/val/test from the bucket
-        local_destination_dir: path to download the data locally
-        verbose:
-        download: dictionary with splits to download
-
-    Returns:
-
-    """
-    if download is None:
-        download = {"train": True, "val": True, "test": True}
-
-    fs = fsspec.filesystem("gs")
-    for split in filenames.keys():
-        if not download[split]:
-            print(f"Skip download {split}")
-            continue
-        for input_target_folder in input_target_folders:
-            folder_local = os.path.join(local_destination_dir, split, input_target_folder)
-            print(f"Downloading {folder_local} if needed")
-            os.makedirs(folder_local, exist_ok=True)
-            for _i, fp in enumerate(filenames[split][input_target_folder]):
-                basename = os.path.basename(fp)
-                file_dest = os.path.join(folder_local, basename)
-                if not os.path.isfile(file_dest):
-                    fs.get_file(f"gs://{bucket_id}/{fp}", file_dest)
-                    print(f"Downloaded ({_i}/{len(filenames[split][input_target_folder])}) {fp}")
-                else:
-                    if verbose:
-                        print(f"{file_dest} already exists")
 
 
 def get_transformations(data_config) -> Tuple[Callable, Callable]:

--- a/ml4floods/models/model_setup.py
+++ b/ml4floods/models/model_setup.py
@@ -16,7 +16,7 @@ SUBSAMPLE_MODULE = {
     "unet_dropout": 8
 }
 
-def get_model(model_config, experiment_name=None):
+def get_model(model_config, normalized_data:bool=True, experiment_name=None):
     """
     Function to setup WorldFloodsModel
     """
@@ -26,7 +26,7 @@ def get_model(model_config, experiment_name=None):
         if model_config.get("model_version","v1") == "v2":
             model = ML4FloodsModel(model_config)
         else:
-            model = WorldFloodsModel(model_config)
+            model = WorldFloodsModel(model_config, normalized_data=normalized_data)
 
         path_to_models = os.path.join(model_config.model_folder,experiment_name, "model.pt").replace("\\","/")
         model.load_state_dict(load(path_to_models))

--- a/ml4floods/models/utils/metrics.py
+++ b/ml4floods/models/utils/metrics.py
@@ -12,8 +12,9 @@ from collections import OrderedDict
 
 
 @torch.no_grad()
-def compute_confusions(ground_truth_outputs: torch.Tensor, test_outputs_categorical: torch.Tensor, num_class: int,
-                       remove_class_zero=False) -> torch.Tensor:
+def compute_confusions(ground_truth_outputs: torch.Tensor,
+                       test_outputs_categorical: torch.Tensor, num_class: int,
+                       remove_class_zero:bool=False) -> torch.Tensor:
     """
     Compute the confusion matrix for a pair of ground truth and predictions. Returns one confusion matrix for each
     element in the batch
@@ -96,7 +97,7 @@ def binary_accuracy(cm_agg)->float:
     tp = cm_agg[1, 1]
     tn = cm_agg[0, 0]
 
-    return (tp+tn) / cm_agg.sum()
+    return (tp+tn) / (cm_agg.sum() + 1e-6)
 
 def binary_precision(cm_agg) -> float:
     tp = cm_agg[1, 1]
@@ -330,7 +331,7 @@ def compute_metrics(dataloader:torch.utils.data.dataloader.DataLoader,
     return out_dict
 
 
-def group_confusion(confusions:torch.Tensor, cems_code:str,fun:Callable,
+def group_confusion(confusions:torch.Tensor, cems_code:np.ndarray,fun:Callable,
                    label_names:List[str]) ->List[Dict[str, Any]]:
     CMs = OrderedDict({c:[] for c in sorted(np.unique(cems_code))})
 

--- a/ml4floods/models/worldfloods_model.py
+++ b/ml4floods/models/worldfloods_model.py
@@ -42,8 +42,8 @@ class WorldFloodsModel(pl.LightningModule):
         """
         Args:
             batch: includes
-                x (torch.Tensor): (B,  C, W, H), input image
-                y (torch.Tensor): (B, W, H) encoded as {0: invalid, 1: land, 2: water, 3: cloud}
+                x (torch.Tensor): (B, C, W, H), input image
+                y (torch.Tensor): (B, 1, W, H) encoded as {0: invalid, 1: land, 2: water, 3: cloud}
         """
         x, y = batch['image'], batch['mask'].squeeze(1)
         logits = self.network(x)


### PR DESCRIPTION
Refactoring of the pytorch-lightning data module and the mechanics to obtain the dataset (in `models/dataset_setup.py`). Some of the changes include:
* Removing duplicated lightning data module that was used to load the data directly from the bucket (same functionallity is achived now with the `WorldFloodsDataModule` class).
*  `WorldFloodsDataModule` always expects now the dictionary with the train/val/test split.
* In `models/dataset_setup.py` the `get_dataset` function is much simpler.
* Implemented function `process_filename_train_test` in `models/dataset_setup.py`  to load the `filenames_train_test` dictionary and which checks that all files exist. This function also downloads the data from the bucket if required.
* Some minor changes in `models.worldfloods_model` to disable logging images and normalization for logging.
*